### PR TITLE
mail repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ EMAIL_PORT=587
 EMAIL_HOST_USER=rnapolis@cs.put.poznan.pl
 EMAIL_HOST_PASSWORD=secret_password
 
-RESULT_BASE_URL=http://localhost:8000/api/getResults/
+RESULT_BASE_URL=http://127.0.0.1:3000/results
 
 TEMPLATE_PATH_JOB_CREATED=email_templates/template_job_created.html
 TEMPLATE_PATH_JOB_FINISHED=email_templates/template_job_finished.html


### PR DESCRIPTION
RESULT_BASE_URL prowadził do API backendu, nie strony z wynikami.

<img width="834" height="538" alt="obraz" src="https://github.com/user-attachments/assets/f4a98d7c-488e-4dfe-8b92-75900713a965" />
<img width="1904" height="1077" alt="obraz" src="https://github.com/user-attachments/assets/639a232b-40b3-440a-b767-b4c5db9e1f80" />
